### PR TITLE
WAYM: skip buff extraction when object has no buff fields

### DIFF
--- a/PublicStardewMods/WhatAreYouMissing/ItemDisplayInfo.cs
+++ b/PublicStardewMods/WhatAreYouMissing/ItemDisplayInfo.cs
@@ -154,6 +154,12 @@ namespace WhatAreYouMissing
         {
             Dictionary<string, string> nameOfBuffs = new Dictionary<string, string>();
             string[] buffs = null;
+
+            // objects without buffs may not have the final two objectInformation fields
+            if (Game1.objectInformation[ParentSheetIndex].Split('/').Length <= SObject.objectInfoBuffTypesIndex) {
+                return nameOfBuffs;
+            }
+
             try
             {
                 buffs = Game1.objectInformation[ParentSheetIndex].Split('/')[SObject.objectInfoBuffTypesIndex].Split(' ');


### PR DESCRIPTION
In the WAYM code there's a point that logs a console warning for mod-created items that have no buffs, in my particular case BBQ Sauce:

`[What Are You Missing] There was no buff index. Data: BBQ Sauce/75/-300/Basic -7/BBQ Sauce/A sauce that usually has varying local flavors and additions. It adds a smoky touch to meat.`

Looking at some old decompiled SDV code, the logic to handle this checks the number of fields and skips buff processing if the buff fields aren't present.

https://github.com/AdamMcIntosh/StawdewValley/blob/31967c9ec25ff89f426b585d52cf59aa3faf9d31/Menus/IClickableMenu.cs#L632

This patch uses that approach to skip buff processing when there are no buffs, while leaving the error detection logic in place in case invalid (non-missing) buffs data is returned from objectInformation. Testing locally seems to indicate that the error no longer appears, and it still seems to function as expected (including mouseover-Info showing cooked food buffs).